### PR TITLE
Fix README: Beschreibung Auth-Usecase

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ benutze [![Authentication](https://img.shields.io/badge/Auth-OAuth2-green)](http
 
 | Scope                                  | API-Usecase                                                      |
 | -------------------------------------- | ---------------------------------------------------------------- |
-| `baufinanzierung:vorgang:schreiben`    | Baufinanzierungsvorgänge anlegen                                 |
+| `baufinanzierung:vorgang:schreiben`    | Baufinanzierungsvorgänge ändern                                 |
 | `baufinanzierung:echtgeschaeft`        | Vorgänge in Produktion ändern, ansonsten nur Testmodus möglich   |
 
 ## Beispiel


### PR DESCRIPTION
Hier sollte "ändern" an Stelle von "anlegen" stehen: 

<img width="1088" alt="Bildschirmfoto 2021-02-25 um 10 52 43" src="https://user-images.githubusercontent.com/7271174/109136117-12baee00-7758-11eb-920d-bb5a17c1dc87.png">
