### PR TITLE
Release 1.1.4 - Erweiterung der Verbundweiterleitungs-Angaben um Angaben zur Provision

### DIFF
--- a/produktanbieter-vertrieb-openapi.json
+++ b/produktanbieter-vertrieb-openapi.json
@@ -9,7 +9,7 @@
       "url" : "http://developer.europace.de",
       "email" : "devsupport@europace2.de"
     },
-    "version" : "1.1.3; afe20af6078639d29890f2f82b9f573d6758d550"
+    "version" : "1.1.4; 0d20e5be303fd008b8761055cbade115cb41dbe4"
   },
   "servers" : [ {
     "url" : "https://baufinanzierung.api.europace.de",
@@ -72,6 +72,9 @@
           "404" : {
             "description" : "Der Vorgang existiert nicht"
           },
+          "401" : {
+            "description" : "Die Authentifizierung ist fehlgeschlagen"
+          },
           "403" : {
             "description" : "Es fehlt die Berechtigung, um die Anfrage auszuführen",
             "content" : {
@@ -91,9 +94,6 @@
                 }
               }
             }
-          },
-          "401" : {
-            "description" : "Die Authentifizierung ist fehlgeschlagen"
           },
           "200" : {
             "description" : "Produktanbietervertriebsangaben in existierenden Vorgang importiert"
@@ -120,6 +120,9 @@
       "AllgemeineVerbundweiterleitungAngaben" : {
         "type" : "object",
         "properties" : {
+          "provision" : {
+            "$ref" : "#/components/schemas/VerbundweiterleitungProvision"
+          },
           "reservierung" : {
             "$ref" : "#/components/schemas/VerbundweiterleitungReservierung"
           },
@@ -196,6 +199,22 @@
           }
         },
         "description" : "Produktanbietervertriebsspezifische Verbundweiterleitungs-Angaben zu einem Vorgang"
+      },
+      "VerbundweiterleitungProvision" : {
+        "type" : "object",
+        "properties" : {
+          "kundenbetreuerProvision" : {
+            "type" : "number",
+            "description" : "Provisionsanteil in Euro des Kundenbetreuers des weitergeleiteten Antrags an der Vertriebsprovision des Verbunddarlehens",
+            "format" : "double"
+          },
+          "vertriebsProvisionGesamt" : {
+            "type" : "number",
+            "description" : "Gesamte Vertriebsprovision des Verbunddarlehens im weitergeleiteten Antrag",
+            "format" : "double"
+          }
+        },
+        "description" : "Angaben zur Provision aus dem weitergeleiteten Antrag"
       },
       "VerbundweiterleitungReservierung" : {
         "required" : [ "einstandsdatum" ],

--- a/produktanbieter-vertrieb-openapi.yaml
+++ b/produktanbieter-vertrieb-openapi.yaml
@@ -8,7 +8,7 @@ info:
     name: Europace AG
     url: http://developer.europace.de
     email: devsupport@europace2.de
-  version: 1.1.3; afe20af6078639d29890f2f82b9f573d6758d550
+  version: 1.1.4; 0d20e5be303fd008b8761055cbade115cb41dbe4
 servers:
 - url: https://baufinanzierung.api.europace.de
   description: Produktionsserver
@@ -60,6 +60,8 @@ paths:
       responses:
         "404":
           description: Der Vorgang existiert nicht
+        "401":
+          description: Die Authentifizierung ist fehlgeschlagen
         "403":
           description: "Es fehlt die Berechtigung, um die Anfrage auszuführen"
           content:
@@ -72,8 +74,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "401":
-          description: Die Authentifizierung ist fehlgeschlagen
         "200":
           description: Produktanbietervertriebsangaben in existierenden Vorgang importiert
         "400":
@@ -92,6 +92,8 @@ components:
     AllgemeineVerbundweiterleitungAngaben:
       type: object
       properties:
+        provision:
+          $ref: '#/components/schemas/VerbundweiterleitungProvision'
         reservierung:
           $ref: '#/components/schemas/VerbundweiterleitungReservierung'
         untervermittler:
@@ -166,6 +168,20 @@ components:
           $ref: '#/components/schemas/AllgemeineVerbundweiterleitungAngaben'
       description: Produktanbietervertriebsspezifische Verbundweiterleitungs-Angaben
         zu einem Vorgang
+    VerbundweiterleitungProvision:
+      type: object
+      properties:
+        kundenbetreuerProvision:
+          type: number
+          description: Provisionsanteil in Euro des Kundenbetreuers des weitergeleiteten
+            Antrags an der Vertriebsprovision des Verbunddarlehens
+          format: double
+        vertriebsProvisionGesamt:
+          type: number
+          description: Gesamte Vertriebsprovision des Verbunddarlehens im weitergeleiteten
+            Antrag
+          format: double
+      description: Angaben zur Provision aus dem weitergeleiteten Antrag
     VerbundweiterleitungReservierung:
       required:
       - einstandsdatum


### PR DESCRIPTION
- Erweiterung der Verbundweiterleitungs-Angaben um Angaben zur Provision des Kundenbetreuers und der Vertriebs-Gesamt-Provision

## Beispiel-Request

```json
{
  "scoring": {
    "olb": {
      "bonitaetsklasse": "KLASSE_8"
    }
  },
  "kondition": {
    "olb": {
      "abschlaege": [
        "NEUKUNDE"
      ]
    }
  },
  "verbundweiterleitung": {
    "allgemein": {
      "provision": {
        "kundenbetreuerProvision": 451.0,
        "vertriebsProvisionGesamt": 1234.5
      },
      "reservierung": {
        "einstandsdatum": "2022-10-06T10:15:12.345"
      },
      "untervermittler": {
        "partnerId": "ABC12",
        "firmierung": "Kauf dich glücklich GmbH",
        "vorname": "Sasha",
        "nachname": "Vermittler",
        "telefonnummer": "0815/123456789",
        "vertriebsOrganisation": "Genopace",
        "anschrift": {
          "strasse": "Heidestraße",
          "hausnummer": "8",
          "plz": "10557",
          "ort": "Berlin"
        }
      }
    }
  }
}
```

Closes https://github.com/hypoport/ep-geno-verbundweiterleitung/issues/132