### PR TITLE
Release 1.1.6

### DIFF
--- a/produktanbieter-vertrieb-openapi.json
+++ b/produktanbieter-vertrieb-openapi.json
@@ -9,7 +9,7 @@
       "url" : "http://developer.europace.de",
       "email" : "devsupport@europace2.de"
     },
-    "version" : "1.1.5; 082f526249983852ca01f0f8ef963434db39e032"
+    "version" : "1.1.6; 4a478e57af075743a37c2f227611841422da243f"
   },
   "servers" : [ {
     "url" : "https://baufinanzierung.api.europace.de",
@@ -92,11 +92,11 @@
               }
             }
           },
-          "200" : {
-            "description" : "Produktanbietervertriebsangaben in existierenden Vorgang importiert"
-          },
           "401" : {
             "description" : "Die Authentifizierung ist fehlgeschlagen"
+          },
+          "200" : {
+            "description" : "Produktanbietervertriebsangaben in existierenden Vorgang importiert"
           },
           "400" : {
             "description" : "Der Request hat ein fehlerhaftes Format oder der Datentyp eines Felds weicht von der Spezifikation ab.",
@@ -120,6 +120,13 @@
       "AllgemeineVerbundweiterleitungAngaben" : {
         "type" : "object",
         "properties" : {
+          "ursprungsDarlehen" : {
+            "type" : "array",
+            "description" : "Liste von Angaben zu den Ursprungsdarlehen",
+            "items" : {
+              "$ref" : "#/components/schemas/VerbundweiterleitungUrsprungsDarlehen"
+            }
+          },
           "provision" : {
             "$ref" : "#/components/schemas/VerbundweiterleitungProvision"
           },
@@ -292,6 +299,16 @@
           }
         },
         "description" : "Anschrift eines Untervermittlers"
+      },
+      "VerbundweiterleitungUrsprungsDarlehen" : {
+        "type" : "object",
+        "properties" : {
+          "produktId" : {
+            "type" : "string",
+            "description" : "Die Produkt-/ProduzentenId"
+          }
+        },
+        "description" : "Angaben zum Ursprungsdarlehen"
       },
       "Problem" : {
         "required" : [ "status", "title", "type" ],

--- a/produktanbieter-vertrieb-openapi.yaml
+++ b/produktanbieter-vertrieb-openapi.yaml
@@ -8,7 +8,7 @@ info:
     name: Europace AG
     url: http://developer.europace.de
     email: devsupport@europace2.de
-  version: 1.1.5; 082f526249983852ca01f0f8ef963434db39e032
+  version: 1.1.6; 4a478e57af075743a37c2f227611841422da243f
 servers:
 - url: https://baufinanzierung.api.europace.de
   description: Produktionsserver
@@ -72,10 +72,10 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "200":
-          description: Produktanbietervertriebsangaben in existierenden Vorgang importiert
         "401":
           description: Die Authentifizierung ist fehlgeschlagen
+        "200":
+          description: Produktanbietervertriebsangaben in existierenden Vorgang importiert
         "400":
           description: Der Request hat ein fehlerhaftes Format oder der Datentyp eines
             Felds weicht von der Spezifikation ab.
@@ -92,6 +92,11 @@ components:
     AllgemeineVerbundweiterleitungAngaben:
       type: object
       properties:
+        ursprungsDarlehen:
+          type: array
+          description: Liste von Angaben zu den Ursprungsdarlehen
+          items:
+            $ref: '#/components/schemas/VerbundweiterleitungUrsprungsDarlehen'
         provision:
           $ref: '#/components/schemas/VerbundweiterleitungProvision'
         reservierung:
@@ -238,6 +243,13 @@ components:
         ort:
           type: string
       description: Anschrift eines Untervermittlers
+    VerbundweiterleitungUrsprungsDarlehen:
+      type: object
+      properties:
+        produktId:
+          type: string
+          description: Die Produkt-/ProduzentenId
+      description: Angaben zum Ursprungsdarlehen
     Problem:
       required:
       - status


### PR DESCRIPTION
 * `AllgemeineVerbundweiterleitungAngaben` enthalten eine Liste von `VerbundweiterleitungUrsprungsDarlehen` die aktuell jeweils die Produkt-/ProduzentenId des Ursprungsdarlehens enthalten

closes https://github.com/hypoport/ep-geno-verbundweiterleitung/issues/246

## Release-Text

### Titel

Version 1.1.6 - Erweiterung der Verbundweiterleitungs-Angaben zu den Ursprungsdarlehen 

### Text

Die allgemeinen Verbundweiterleitungs-Angaben werden um eine Liste der Angaben zu den Ursprungsdarlehen erweitert. Diese Angaben enthalten aktuell jeweils die Id des Produktes mit der das ursprüngliche Darlehen erzeugt wurde. 

### Beispiel-Request 

```json
{
  "scoring": {
    "olb": {
      "bonitaetsklasse": "KLASSE_8"
    }
  },
  "kondition": {
    "olb": {
      "abschlaege": [
        "NEUKUNDE"
      ]
    }
  },
  "verbundweiterleitung": {
    "allgemein": {
      "ursprungsDarlehen": [
        {
          "produktId": "ProduktId"
        }
      ],
      "provision": {
        "kundenbetreuerProvision": 451.0,
        "vertriebsProvisionGesamt": 1234.5
      },
      "reservierung": {
        "einstandsdatum": "2022-10-06T10:15:12.345"
      },
      "untervermittler": {
        "partnerId": "ABC12",
        "firmierung": "Kauf dich glücklich GmbH",
        "anrede": "Herr",
        "vorname": "Sasha",
        "nachname": "Vermittler",
        "telefonnummer": "0815/123456789",
        "email": "sasha@vermittler.de",
        "registrierungsNummer": "123456",
        "aufsichtsBehoerde": "Berlin",
        "vertriebsOrganisation": "Genopace",
        "vertriebsOrganisationsId": "234567",
        "externerKreditSachbearbeiterId": "345678",
        "anschrift": {
          "strasse": "Heidestraße",
          "hausnummer": "8",
          "plz": "10557",
          "ort": "Berlin"
        }
      }
    }
  }
}
```