### PR TITLE
Release 1.1.7

### DIFF
--- a/produktanbieter-vertrieb-openapi.json
+++ b/produktanbieter-vertrieb-openapi.json
@@ -9,7 +9,7 @@
       "url" : "http://developer.europace.de",
       "email" : "devsupport@europace2.de"
     },
-    "version" : "1.1.6; 4a478e57af075743a37c2f227611841422da243f"
+    "version" : "1.1.7; 132109364df3a65bce03eb2b2357d079775cb2aa"
   },
   "servers" : [ {
     "url" : "https://baufinanzierung.api.europace.de",
@@ -301,6 +301,7 @@
         "description" : "Anschrift eines Untervermittlers"
       },
       "VerbundweiterleitungUrsprungsDarlehen" : {
+        "required" : [ "produktId" ],
         "type" : "object",
         "properties" : {
           "produktId" : {

--- a/produktanbieter-vertrieb-openapi.yaml
+++ b/produktanbieter-vertrieb-openapi.yaml
@@ -8,7 +8,7 @@ info:
     name: Europace AG
     url: http://developer.europace.de
     email: devsupport@europace2.de
-  version: 1.1.6; 4a478e57af075743a37c2f227611841422da243f
+  version: 1.1.7; 132109364df3a65bce03eb2b2357d079775cb2aa
 servers:
 - url: https://baufinanzierung.api.europace.de
   description: Produktionsserver
@@ -244,6 +244,8 @@ components:
           type: string
       description: Anschrift eines Untervermittlers
     VerbundweiterleitungUrsprungsDarlehen:
+      required:
+      - produktId
       type: object
       properties:
         produktId:


### PR DESCRIPTION
- das Attribut `produktId` von VerbundweiterleitungUrsprungsDarlehen darf nicht null sein

Closes https://github.com/genopace/entwicklung/issues/2340

## Release-Text

### Titel

Version 1.1.7 - Die Angabe der ProduktId für Verbundweiterleitung-Ursprungs-Darlehen ist erforderlich  

### Text

Keine Strukturänderung oder Erweiterung der API.

In der Spezifikation der Model-Struktur `VerbundweiterleitungUrsprungsDarlehen`, die mit Release 1.1.6 (#8) eingeführt wurde, ist das Feld `produktId` nun obligatorisch. D.h. es darf nicht `null` sein. 

### Beispiel-Request

siehe #8 